### PR TITLE
fix: 컴파일 에러 안나게 수정

### DIFF
--- a/src/test/kotlin/com/yourssu/assignmentblog/domain/comment/controller/CommentControllerTest.kt
+++ b/src/test/kotlin/com/yourssu/assignmentblog/domain/comment/controller/CommentControllerTest.kt
@@ -74,8 +74,8 @@ internal class CommentControllerTest {
 
             commentService = CommentService(
                 commentRepository = commentRepository,
-                existenceChecker = existenceChecker,
-                ownershipChecker = ownershipChecker
+                articleRepository = articleRepository,
+                userRepository = userRepository
             )
 
             userRepository.save(user)
@@ -120,8 +120,8 @@ internal class CommentControllerTest {
         )
         commentService = CommentService(
             commentRepository = commentRepository,
-            existenceChecker = existenceChecker,
-            ownershipChecker = ownershipChecker
+            articleRepository = articleRepository,
+            userRepository = userRepository
         )
 
         commentController = CommentController(commentService)

--- a/src/test/kotlin/com/yourssu/assignmentblog/domain/comment/service/CommentServiceTest.kt
+++ b/src/test/kotlin/com/yourssu/assignmentblog/domain/comment/service/CommentServiceTest.kt
@@ -69,8 +69,8 @@ internal class CommentServiceTest {
 
             commentService = CommentService(
                 commentRepository = commentRepository,
-                existenceChecker = existenceChecker,
-                ownershipChecker = ownershipChecker
+                articleRepository = articleRepository,
+                userRepository = userRepository
             )
 
             userRepository.save(user)
@@ -113,8 +113,8 @@ internal class CommentServiceTest {
         )
         commentService = CommentService(
             commentRepository = commentRepository,
-            existenceChecker = existenceChecker,
-            ownershipChecker = ownershipChecker
+            articleRepository = articleRepository,
+            userRepository = userRepository
         )
 
     }
@@ -141,12 +141,16 @@ internal class CommentServiceTest {
                         content = "content"
                     )
 
+                    requestDto.setURIAndFailMessage(
+                        currentURI = ArticleServiceTest.WRITE,
+                        failedTargetText = ""
+                    )
+
                     // when-then
                     assertThrows(CustomException::class.java) {
                         commentService.write(
                             articleId = 1,
                             requestDto = requestDto,
-                            currentURI = ArticleServiceTest.WRITE,
                             email = email
                         )
                     }
@@ -190,8 +194,8 @@ internal class CommentServiceTest {
                         )
                         commentService = CommentService(
                             commentRepository = commentRepository,
-                            existenceChecker = existenceChecker,
-                            ownershipChecker = ownershipChecker
+                            articleRepository = articleRepositoryForNotExistTest,
+                            userRepository = userRepository
                         )
 
                         // given
@@ -200,12 +204,16 @@ internal class CommentServiceTest {
                             content = "content"
                         )
 
+                        requestDto.setURIAndFailMessage(
+                            currentURI = WRITE,
+                            failedTargetText = ""
+                        )
+
                         // when-then
                         assertThrows(CustomException::class.java) {
                             commentService.write(
                                 articleId = 1,
                                 requestDto = requestDto,
-                                currentURI = WRITE,
                                 email = email
                             )
                         }
@@ -226,11 +234,15 @@ internal class CommentServiceTest {
                             content = "content"
                         )
 
+                        requestDto.setURIAndFailMessage(
+                            currentURI = WRITE,
+                            failedTargetText = ""
+                        )
+
                         // when
                         val result = commentService.write(
                             articleId = 1,
                             requestDto = requestDto,
-                            currentURI = WRITE,
                             email = email
                         )
 
@@ -263,13 +275,17 @@ internal class CommentServiceTest {
                         content = "content"
                     )
 
+                    requestDto.setURIAndFailMessage(
+                        currentURI = EDIT,
+                        failedTargetText = ""
+                    )
+
                     // when-then
                     assertThrows(CustomException::class.java) {
                         commentService.edit(
                             articleId = 1,
                             commentId = 1,
                             requestDto = requestDto,
-                            currentURI = ArticleServiceTest.EDIT,
                             email = email
                         )
                     }
@@ -313,8 +329,8 @@ internal class CommentServiceTest {
                         )
                         commentService = CommentService(
                             commentRepository = commentRepository,
-                            existenceChecker = existenceChecker,
-                            ownershipChecker = ownershipChecker
+                            articleRepository = articleRepository,
+                            userRepository = userRepository
                         )
 
                         // given
@@ -324,13 +340,17 @@ internal class CommentServiceTest {
                             content = "content"
                         )
 
+                        requestDto.setURIAndFailMessage(
+                            currentURI = EDIT,
+                            failedTargetText = ""
+                        )
+
                         // when-then
                         assertThrows(CustomException::class.java) {
                             commentService.edit(
                                 articleId = 1,
                                 commentId = 1,
                                 requestDto = requestDto,
-                                currentURI = EDIT,
                                 email = email
                             )
                         }
@@ -361,8 +381,8 @@ internal class CommentServiceTest {
                                 )
                                 commentService = CommentService(
                                     commentRepository = commentRepository,
-                                    existenceChecker = existenceChecker,
-                                    ownershipChecker = ownershipChecker
+                                    articleRepository = articleRepository,
+                                    userRepository = userRepository
                                 )
 
                                 // given
@@ -378,7 +398,6 @@ internal class CommentServiceTest {
                                         articleId = 1,
                                         commentId = 1,
                                         requestDto = requestDto,
-                                        currentURI = EDIT,
                                         email = email
                                     )
                                 }
@@ -423,13 +442,17 @@ internal class CommentServiceTest {
                                             content = "content"
                                         )
 
+                                        requestDto.setURIAndFailMessage(
+                                            currentURI = EDIT,
+                                            failedTargetText = ""
+                                        )
+
                                         // when-then
                                         assertThrows(CustomException::class.java) {
                                             commentService.edit(
                                                 articleId = 1,
                                                 commentId = 1,
                                                 requestDto = requestDto,
-                                                currentURI = EDIT,
                                                 email = email
                                             )
                                         }
@@ -451,11 +474,15 @@ internal class CommentServiceTest {
                                             content = "content"
                                         )
 
+                                        requestDto.setURIAndFailMessage(
+                                            currentURI = WRITE,
+                                            failedTargetText = ""
+                                        )
+
                                         // when
                                         val result = commentService.write(
                                             articleId = 1,
                                             requestDto = requestDto,
-                                            currentURI = EDIT,
                                             email = email
                                         )
 
@@ -527,8 +554,8 @@ internal class CommentServiceTest {
                         )
                         commentService = CommentService(
                             commentRepository = commentRepository,
-                            existenceChecker = existenceChecker,
-                            ownershipChecker = ownershipChecker
+                            articleRepository = articleRepository,
+                            userRepository = userRepository
                         )
 
                         // given
@@ -570,8 +597,8 @@ internal class CommentServiceTest {
                                 )
                                 commentService = CommentService(
                                     commentRepository = commentRepository,
-                                    existenceChecker = existenceChecker,
-                                    ownershipChecker = ownershipChecker
+                                    articleRepository = articleRepository,
+                                    userRepository = userRepository
                                 )
 
                                 // given

--- a/src/test/kotlin/com/yourssu/assignmentblog/domain/user/controller/UserControllerTest.kt
+++ b/src/test/kotlin/com/yourssu/assignmentblog/domain/user/controller/UserControllerTest.kt
@@ -57,7 +57,6 @@ internal class UserControllerTest {
 
             userService = UserService(
                 userRepository = userRepository,
-                existenceChecker = existenceChecker,
                 passwordEncoder = passwordEncoder,
             )
 
@@ -79,7 +78,6 @@ internal class UserControllerTest {
         userService = UserService(
             userRepository = userRepository,
             passwordEncoder = passwordEncoder,
-            existenceChecker = existenceChecker
         )
 
         userController = UserController(userService)

--- a/src/test/kotlin/com/yourssu/assignmentblog/domain/user/service/UserServiceTest.kt
+++ b/src/test/kotlin/com/yourssu/assignmentblog/domain/user/service/UserServiceTest.kt
@@ -60,7 +60,6 @@ internal class UserServiceTest {
 
             userService = UserService(
                 userRepository = userRepository,
-                existenceChecker = existenceChecker,
                 passwordEncoder = passwordEncoder,
             )
 
@@ -89,7 +88,6 @@ internal class UserServiceTest {
         userService = UserService(
             userRepository = userRepository,
             passwordEncoder = passwordEncoder,
-            existenceChecker = existenceChecker
         )
     }
 
@@ -111,11 +109,15 @@ internal class UserServiceTest {
                     username = "beomsu"
                 )
 
+                requestDto.setURIAndFailMessage(
+                    currentURI = SIGNUP,
+                    failedTargetText = ""
+                )
+
                 // when-then
                 assertThrows(CustomException::class.java) {
                     userService.signup(
                         requestDto = requestDto,
-                        currentURI = SIGNUP
                     )
                 }
             }
@@ -141,7 +143,6 @@ internal class UserServiceTest {
                 userService = UserService(
                     userRepository = userRepository,
                     passwordEncoder = passwordEncoder,
-                    existenceChecker = existenceChecker
                 )
 
                 // given
@@ -152,10 +153,14 @@ internal class UserServiceTest {
                     role = "USER"
                 )
 
+                requestDto.setURIAndFailMessage(
+                    currentURI = SIGNUP,
+                    failedTargetText = ""
+                )
+
                 // when
                 val result = userService.signup(
                     requestDto = requestDto,
-                    currentURI = SIGNUP
                 )
 
                 // then
@@ -193,7 +198,6 @@ internal class UserServiceTest {
                     userService = UserService(
                         userRepository = userRepository,
                         passwordEncoder = passwordEncoder,
-                        existenceChecker = existenceChecker
                     )
 
                     // given


### PR DESCRIPTION
## Description
> 테스트 코드 컴파일 에러 안 나게 수정

## Main Features
- 테스트 코드가 컴파일 에러가 나지 않게 수정했습니다.
- 그래도 실행하면 테스트가 깨질텐데, 그 부분은 차후 수정합니다.
